### PR TITLE
Feat/add course related entity

### DIFF
--- a/database.dbml
+++ b/database.dbml
@@ -33,10 +33,11 @@ Table courses {
     name varchar(255) [not null, note: "課程名稱"]
     organization int [not null, ref: > organizations.id, note: "所屬組織（通常是學校，如靜宜大學等）"]
     description varchar(255) [note: "課程敘述"]
+    link varchar(255) [not null, note: "課程連結（通常是課程網頁）"]
     credits int [note: "學分數"]
     tags int [ref: <> tags.id, note: "課程屬性（如必修、選修、必選修等）"]
     places int [not null, ref: > places.id, note: "上課地點"]
-    date_range int [not null, ref: > date_ranges.id, note: "開課日期範圍"]
+    date_range int [ref: > date_ranges.id, note: "開課日期範圍"]
     time_range int [ref: <> time_ranges.id, note: "每週上課時間"]
     host int [ref: <> persons.id, note: "講師、負責人"]
 
@@ -55,7 +56,7 @@ Table tags {
 Table places {
     id int [pk, increment]
     name varchar(255) [not null, note: "地點名稱"]
-    description varchar(255) [note: "地點敘述"]
+    description varchar(255) [not null, note: "地點敘述"]
     parent int [ref: < places.child, note: "父地點（例如主顧樓 509 > 主顧樓 > 靜宜大學）"]
     child int
 

--- a/src/main/java/io/charkchalk/backend/entity/Branch.java
+++ b/src/main/java/io/charkchalk/backend/entity/Branch.java
@@ -1,0 +1,24 @@
+package io.charkchalk.backend.entity;
+
+import lombok.*;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "branches")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class Branch {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    // OneToMany
+    @OneToMany(mappedBy = "on_branch", orphanRemoval = true)
+    @ToString.Exclude
+    private Collection<Course> courses = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/Course.java
+++ b/src/main/java/io/charkchalk/backend/entity/Course.java
@@ -1,0 +1,78 @@
+package io.charkchalk.backend.entity;
+
+import lombok.*;
+import javax.persistence.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "courses")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class Course {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "code")
+    private String code;
+
+    @ManyToOne
+    @JoinColumn(name = "on_branch_id", nullable = false)
+    private Branch on_branch;
+
+    @ManyToOne
+    @JoinColumn(name = "predecessor_id")
+    private Course predecessor;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "link")
+    private URL link;
+
+    @Column(name = "credits")
+    private Integer credits;
+
+    @ManyToMany
+    @JoinTable(name = "courses_tags",
+            joinColumns = @JoinColumn(name = "course_id"),
+            inverseJoinColumns = @JoinColumn(name = "tags_id"))
+    @ToString.Exclude
+    private Collection<Tag> tags = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @ManyToOne
+    @JoinColumn(name = "date_id")
+    private DateRange dateRange;
+
+    @ManyToOne
+    @JoinColumn(name = "time_id")
+    private TimeRange timeRange;
+
+    @ManyToMany
+    @JoinTable(name = "courses_persons",
+            joinColumns = @JoinColumn(name = "course_id"),
+            inverseJoinColumns = @JoinColumn(name = "person_id"))
+    @ToString.Exclude
+    private Collection<Person> hosts = new ArrayList<>();
+
+    // OneToMany
+    @OneToMany(mappedBy = "predecessor", orphanRemoval = true)
+    @ToString.Exclude
+    private Collection<Course> child = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/DateRange.java
+++ b/src/main/java/io/charkchalk/backend/entity/DateRange.java
@@ -1,0 +1,35 @@
+package io.charkchalk.backend.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "date_range")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class DateRange {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    // OneToMany
+    @OneToMany(mappedBy = "dateRange")
+    @ToString.Exclude
+    private Collection<Course> courses = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/Organization.java
+++ b/src/main/java/io/charkchalk/backend/entity/Organization.java
@@ -1,0 +1,41 @@
+package io.charkchalk.backend.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "organizations")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class Organization {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @ManyToMany
+    @JoinTable(name = "organizations_tags",
+            joinColumns = @JoinColumn(name = "organization_id"),
+            inverseJoinColumns = @JoinColumn(name = "tags_id"))
+    @ToString.Exclude
+    private Collection<Tag> tags = new ArrayList<>();
+
+    // OneToMany
+    @OneToMany(mappedBy = "organization", orphanRemoval = true)
+    @ToString.Exclude
+    private Collection<Course> courses = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/Person.java
+++ b/src/main/java/io/charkchalk/backend/entity/Person.java
@@ -1,0 +1,37 @@
+package io.charkchalk.backend.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "persons")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class Person {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "link", nullable = false)
+    private URL link;
+
+    @ManyToMany(mappedBy = "hosts")
+    @ToString.Exclude
+    private Collection<Course> courses = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/Place.java
+++ b/src/main/java/io/charkchalk/backend/entity/Place.java
@@ -1,0 +1,41 @@
+package io.charkchalk.backend.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "places")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class Place {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Place parent;
+
+    @OneToMany(mappedBy = "parent")
+    @ToString.Exclude
+    private Collection<Place> children;
+
+    @OneToMany(mappedBy = "place")
+    @ToString.Exclude
+    private Collection<Course> courses = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/Tag.java
+++ b/src/main/java/io/charkchalk/backend/entity/Tag.java
@@ -1,0 +1,42 @@
+package io.charkchalk.backend.entity;
+
+import io.charkchalk.backend.entity.enums.TagLimit;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Entity
+@Table(name = "tags")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Enumerated
+    @Column(name = "tag_limit")
+    private TagLimit tagLimit;
+
+    @ManyToMany(mappedBy = "tags")
+    @ToString.Exclude
+    private Collection<Course> courses = new ArrayList<>();
+
+    @ManyToMany(mappedBy = "tags")
+    @ToString.Exclude
+    private Collection<Organization> organizations = new ArrayList<>();
+}

--- a/src/main/java/io/charkchalk/backend/entity/TimeRange.java
+++ b/src/main/java/io/charkchalk/backend/entity/TimeRange.java
@@ -1,0 +1,37 @@
+package io.charkchalk.backend.entity;
+
+import io.charkchalk.backend.entity.enums.Week;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.time.LocalTime;
+import java.util.TimeZone;
+
+@Entity
+@Table(name = "time_range")
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+public class TimeRange {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "timezone", nullable = false)
+    private TimeZone timeZone;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Enumerated
+    @Column(name = "week")
+    private Week week;
+}

--- a/src/main/java/io/charkchalk/backend/entity/enums/TagLimit.java
+++ b/src/main/java/io/charkchalk/backend/entity/enums/TagLimit.java
@@ -1,0 +1,5 @@
+package io.charkchalk.backend.entity.enums;
+
+public enum TagLimit {
+    COURSES, ORGANIZATIONS, COMBINATIONS
+}

--- a/src/main/java/io/charkchalk/backend/entity/enums/Week.java
+++ b/src/main/java/io/charkchalk/backend/entity/enums/Week.java
@@ -1,0 +1,5 @@
+package io.charkchalk.backend.entity.enums;
+
+public enum Week {
+    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation= true
+spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.PostgreSQLDialect
+
+# Hibernate ddl auto (create, create-drop, validate, update)
+#spring.jpa.hibernate.ddl-auto= create-drop
+spring.jpa.hibernate.ddl-auto= create


### PR DESCRIPTION
All entities except combinations are created. The combinations will wait until the course-related repository is implemented.

Hibernate ORM can use this to generate the following tables and associations (including many-to-many relationships) in PostgreSQL:

![image](https://user-images.githubusercontent.com/26710554/194746182-f2e24509-3de9-492a-afc4-3cb2fd227ba1.png)